### PR TITLE
[0.4.0] delegates are now functions to avoid creating a ton of classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,19 +153,17 @@ result = marshal.unmarshal(TestWithValidate, {'name': 'foo'})
 
 This can be used to validate the python object right at construction, potentially raising an error if any of the fields have invalid values
 
-It's also possible to register your own custom unmarshaler for specific user defined classes.
+It's also possible to register your own custom unmarshaler for specific user defined classes by passing in a function pointer that will "resolve" the raw data
 
 ```python
 from dataclasses import dataclass
 
-from pymarshaler.arg_delegates import ArgBuilderDelegate 
 from pymarshaler.marshal import Marshal
 
 
 @dataclass
 class ClassWithMessage:
-    
-    message: str        
+    message: str
 
 
 class ClassWithCustomDelegate:
@@ -174,17 +172,12 @@ class ClassWithCustomDelegate:
         self.message_obj = message_obj
 
 
-class CustomDelegate(ArgBuilderDelegate):
-
-    def __init__(self, cls):
-        super().__init__(cls)
-
-    def resolve(self, data):
-        return ClassWithCustomDelegate(ClassWithMessage(data['message']))
+def custom_delegate(data):
+    return ClassWithCustomDelegate(ClassWithMessage(data['message']))
 
 
 marshal = Marshal()
-marshal.register_delegate(ClassWithCustomDelegate, CustomDelegate)
+marshal.register_delegate(ClassWithCustomDelegate, custom_delegate)
 result = marshal.unmarshal(ClassWithCustomDelegate, {'message': 'Hello from the custom delegate!'})
 print(result.message_obj)
 >>> 'Hello from the custom delegate!'

--- a/pymarshaler/__init__.py
+++ b/pymarshaler/__init__.py
@@ -1,7 +1,7 @@
-__version__ = '0.3.3'
+__version__ = '0.4.0'
 __all__ = ['Marshal', 'utils', 'arg_delegates', 'errors']
 
-from pymarshaler.marshal import Marshal
-from pymarshaler import utils
 from pymarshaler import arg_delegates
 from pymarshaler import errors
+from pymarshaler import utils
+from pymarshaler.marshal import Marshal

--- a/pymarshaler/arg_delegates.py
+++ b/pymarshaler/arg_delegates.py
@@ -1,130 +1,66 @@
-import datetime
-import typing
-
 import dateutil.parser as parser
 
 from pymarshaler.errors import UnknownFieldError
 from pymarshaler.utils import get_init_params
 
 
-class ArgBuilderDelegate:
-
-    def __init__(self, cls):
-        self.cls = cls
-
-    def resolve(self, data):
-        raise NotImplementedError(f'{ArgBuilderDelegate.__name__} has no implementation of resolve')
+def enum_delegate(cls, data, ignore_func):
+    for v in cls.__members__.values():
+        if v.value == data:
+            return v
+    raise UnknownFieldError(f'Invalid value {data} for enum {cls.__name__}')
 
 
-class FunctionalArgBuilderDelegate(ArgBuilderDelegate):
-
-    def __init__(self, cls, func):
-        super().__init__(cls)
-        self.func = func
-
-    def resolve(self, data):
-        raise NotImplementedError(f'{FunctionalArgBuilderDelegate.__name__} has no implementation of resolve')
+def list_delegate(cls, data, func):
+    inner_type = cls.__args__[0]
+    return [func(inner_type, x) for x in data]
 
 
-class EnumArgBuilderDelegate(ArgBuilderDelegate):
-
-    def resolve(self, data):
-        for v in self.cls.__members__.values():
-            if v.value == data:
-                return v
-        raise UnknownFieldError(f'Invalid value {data} for enum {self.cls.__name__}')
+def set_builder_delegate(cls, data, func):
+    inner_type = cls.__args__[0]
+    return {func(inner_type, x) for x in data}
 
 
-class ListArgBuilderDelegate(FunctionalArgBuilderDelegate):
-
-    def __init__(self, cls, func):
-        super().__init__(cls, func)
-
-    def resolve(self, data: typing.List):
-        inner_type = self.cls.__args__[0]
-        return [self.func(inner_type, x) for x in data]
+def tuple_delegate(cls, data, func):
+    inner_type = cls.__args__[0]
+    return (func(inner_type, x) for x in data)
 
 
-class SetArgBuilderDelegate(FunctionalArgBuilderDelegate):
-
-    def __init__(self, cls, func):
-        super().__init__(cls, func)
-
-    def resolve(self, data: typing.Set):
-        inner_type = self.cls.__args__[0]
-        return {self.func(inner_type, x) for x in data}
+def dict_delegate(cls, data, func):
+    key_type = cls.__args__[0]
+    value_type = cls.__args__[1]
+    return {
+        func(key_type, key): func(value_type, value) for key, value in data.items()
+    }
 
 
-class TupleArgBuilderDelegate(FunctionalArgBuilderDelegate):
-
-    def __init__(self, cls, func):
-        super().__init__(cls, func)
-
-    def resolve(self, data: typing.Tuple):
-        inner_type = self.cls.__args__[0]
-        return (self.func(inner_type, x) for x in data)
+def builtin_delegate(cls, data, ignore_func):
+    if data is None:
+        return None
+    else:
+        return cls(data)
 
 
-class DictArgBuilderDelegate(FunctionalArgBuilderDelegate):
-
-    def __init__(self, cls, func):
-        super().__init__(cls, func)
-
-    def resolve(self, data: dict):
-        key_type = self.cls.__args__[0]
-        value_type = self.cls.__args__[1]
-        return {
-            self.func(key_type, key): self.func(value_type, value) for key, value in data.items()
-        }
+def datetime_delegate(cls_ignore, data, ignore_func=None):
+    return parser.parse(data)
 
 
-class BuiltinArgBuilderDelegate(ArgBuilderDelegate):
-
-    def __init__(self, cls):
-        super().__init__(cls)
-
-    def resolve(self, data):
-        if data is None:
-            return None
-        else:
-            return self.cls(data)
-
-
-class DateTimeArgBuilderDelegate(ArgBuilderDelegate):
-
-    def __init__(self):
-        super().__init__(datetime.datetime)
-
-    def resolve(self, data):
-        return parser.parse(data)
-
-
-class UserDefinedArgBuilderDelegate(FunctionalArgBuilderDelegate):
-
-    def __init__(self, cls, func, ignore_unknown_fields: bool, walk_unknown_fields: bool):
-        super().__init__(cls, func)
-        self.ignore_unknown_fields = ignore_unknown_fields
-        self.walk_unknown_fields = walk_unknown_fields
-
-    def resolve(self, data: dict):
-        return self._resolve(self.cls, data)
-
-    def _resolve(self, cls, data: dict):
-        args = {}
-        unsatisfied = get_init_params(cls)
-        for key, value in data.items():
-            if key in unsatisfied:
-                param_type = unsatisfied[key]
-                args[key] = self.func(param_type, value)
-            elif not self.ignore_unknown_fields:
-                raise UnknownFieldError(f'Found unknown field ({key}: {value}). '
-                                        'If you would like to skip unknown fields '
-                                        'create a Marshal object who can skip ignore_unknown_fields')
-            elif self.walk_unknown_fields:
-                if isinstance(value, dict):
-                    args.update(self._resolve(cls, value))
-                elif isinstance(value, (list, set, tuple)):
-                    for x in value:
-                        if isinstance(x, dict):
-                            args.update(self._resolve(cls, x))
-        return args
+def user_defined_delegate(cls, data, func, ignore_unknown_fields: bool, walk_unknown_fields: bool):
+    args = {}
+    unsatisfied = get_init_params(cls)
+    for key, value in data.items():
+        if key in unsatisfied:
+            param_type = unsatisfied[key]
+            args[key] = func(param_type, value)
+        elif not ignore_unknown_fields:
+            raise UnknownFieldError(f'Found unknown field ({key}: {value}). '
+                                    'If you would like to skip unknown fields '
+                                    'create a Marshal object who can skip ignore_unknown_fields')
+        elif walk_unknown_fields:
+            if isinstance(value, dict):
+                args.update(user_defined_delegate(cls, value, func, ignore_unknown_fields, walk_unknown_fields))
+            elif isinstance(value, (list, set, tuple)):
+                for x in value:
+                    if isinstance(x, dict):
+                        args.update(user_defined_delegate(cls, x, func, ignore_unknown_fields, walk_unknown_fields))
+    return args

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name="pymarshaler",
-    version='0.3.3',
+    version='0.4.0',
     author="Hernan Romer",
     author_email="nanug33@gmail.com",
     description="Package to marshal and unmarshal python objects",

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Dict
 
-from pymarshaler.arg_delegates import ArgBuilderDelegate
-
 
 @dataclass
 class Inner:
@@ -75,16 +73,6 @@ class ClassWithValidate:
 class ClassWithCustomDelegate:
 
     pass
-
-
-@dataclass
-class CustomNoneDelegate(ArgBuilderDelegate):
-
-    def __init__(self, cls):
-        super().__init__(cls)
-
-    def resolve(self, data):
-        return ClassWithCustomDelegate()
 
 
 @dataclass

--- a/tests/test_marshaling.py
+++ b/tests/test_marshaling.py
@@ -134,7 +134,7 @@ class TestMarshalling(unittest.TestCase):
 
     @timed
     def test_custom_delegate(self):
-        marshal.register_delegate(ClassWithCustomDelegate, CustomNoneDelegate)
+        marshal.register_delegate(ClassWithCustomDelegate, lambda x: ClassWithCustomDelegate())
         result = marshal.unmarshal(ClassWithCustomDelegate, {})
         self.assertEqual(result, ClassWithCustomDelegate())
 

--- a/tests/timed.py
+++ b/tests/timed.py
@@ -11,8 +11,13 @@ def timed(function):
     """
     @wraps(function)
     def wrapper(*args, **kwargs):
-        start = timer()
-        result = function(*args, **kwargs)
-        print("{} took {} ms".format(function.__name__, round(1000 * (timer() - start), 3)))
+        total_time = 0
+        result = None
+
+        for _ in range(5):
+            start = timer()
+            result = function(*args, **kwargs)
+            total_time += timer() - start
+        print("{} took {} ms".format(function.__name__, round(1000 * (total_time / 5), 3)))
         return result
     return wrapper


### PR DESCRIPTION
Rather than using classes as delegates, we use functions. This means we aren't spawning classes for every single call to `resolve`. 

This will change up how this package is used which I think is acceptable given that we are on version < 1